### PR TITLE
add extral dev command so that it can watch the changes and build automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "stage": "mkdir dist || echo Dist already exists.",
     "bundle": "esbuild src/gmailJsLoader.js src/extension.js --outdir=dist/ --bundle --sourcemap --target=es6",
     "devbuild": "cp ../gmail.js/src/gmail.js node_modules/gmail-js/src/ && npm run build",
-    "build": "npm run stage && npm run bundle"
+    "build": "npm run stage && npm run bundle",
+    "dev": "npm run bundle -- --watch"
   },
   "author": "Jostein kjønigsen",
   "license": "ISC",


### PR DESCRIPTION
### Current behavior:
- make changes to extension code
- run `build` manually so that the bundle can update


### Change:
- add an extra script `dev`
- it runs the `bundle` script with `--watch` param
- so it will keeps watching the code changing and update the bundle to **dist** folder automatically


### Useage
- just run `yarn dev` or `npm run dev`